### PR TITLE
No TLS update for base.yaml

### DIFF
--- a/conf/homeserver.yaml.d/base.yaml
+++ b/conf/homeserver.yaml.d/base.yaml
@@ -212,3 +212,4 @@ tls_certificate_path: "/secrets/tls.crt"
 tls_private_key_path: "/secrets/tls.key"
 tls_dh_params_path: "/secrets/tls.dh"
 tls_fingerprints: []
+{% endif %}

--- a/conf/homeserver.yaml.d/base.yaml
+++ b/conf/homeserver.yaml.d/base.yaml
@@ -206,8 +206,9 @@ listeners:
   {% endif %}
 
 ## TLS ##
+no_tls: {{ "True" if SYNAPSE_NO_TLS else "False" }}
+{% if not SYNAPSE_NO_TLS %}
 tls_certificate_path: "/secrets/tls.crt"
 tls_private_key_path: "/secrets/tls.key"
 tls_dh_params_path: "/secrets/tls.dh"
-no_tls: {{ "True" if SYNAPSE_NO_TLS else "False" }}
 tls_fingerprints: []


### PR DESCRIPTION
I'm getting a error " Error accessing file '/secrets/tls.crt' (config for tls_certificate): No such file or directory", and I think this might fix the problem. I'm using -e SYNAPSE_NO_TLS=True, so I'm pretty sure the problem is that the tls paths are always defined in the base.yaml.